### PR TITLE
トルク上限を追加し発熱を抑制する

### DIFF
--- a/example/main.cpp
+++ b/example/main.cpp
@@ -254,6 +254,7 @@ void motor_thread(int usb_port_index)
 
     // set cmd
     double torque_max = 23.5;
+    double torque_limit = 9.0; // 参考：9 Nmは倒立を約300s程度続けて58℃
     for(int i=0; i<NUM_MOTOR_PER_USB_PORT; i++)
     {
       int motor_id = usb_port_index*NUM_MOTOR_PER_USB_PORT + i;
@@ -286,6 +287,13 @@ void motor_thread(int usb_port_index)
       cmd[i].dq     = (float) target_vel[i] * 6.33;
       cmd[i].kp   = (float) kp[i] / ( 6.33 * 6.33 );
       cmd[i].kd   = (float) kd[i] / ( 6.33 * 6.33 );
+      // safety for position control. Torque limit
+      double torque_estimate = cmd[i].kp*( target_pos[i]  - measured_pos[i])* 6.33 * 6.33; //+ cmd[i].kd*( target_vel[i] - measured_vel[i]);
+      cmd[i].kp = (float) std::min(1.0, torque_limit/std::abs(torque_estimate)) * cmd[i].kp;
+      // std::cout 
+      // << "error_pos:" << target_pos[i] - runtime_offset_pos[i] - measured_pos[i]
+      // << ", torque_estimate: " << torque_estimate
+      // << std::endl;
       #endif
 
       #if (ENABLE_LEGMOTOR > 0)
@@ -342,6 +350,11 @@ void motor_thread(int usb_port_index)
           std::cout
           <<"["<<usb_port_index<<"]"<<"["<<i<<"]"
           <<" torque_control: "<<torque_control_for_print[i]<<std::endl;
+          // std::cout // debug
+          // <<"["<<usb_port_index<<"]"<<"["<<i<<"]" 
+          // << "error_pos:" << target_pos[i] - measured_pos[i]
+          // << ", torque_estimate: " << cmd[i].kp*( target_pos[i] - measured_pos[i]) * 6.33 * 6.33
+          // << std::endl;
         std::cout
           <<"["<<usb_port_index<<"]"<<"["<<i<<"]"
           <<" target_pos: "<<target_pos_for_print[i]


### PR DESCRIPTION
倒立時に股が徐々に開脚することにより、トルクが増大しモータが発熱する問題に対してトルクの上限を設ける形で温度上昇を抑制しました。

Goモータでは明示的なトルク上限を設けることはできません。
また倒立時のトルクの支配的な項はP制御のトルクであるため、こちらに擬似的な制限を設けることにしました。
具体的には、偏差にPゲインをかけたものがトルクとなるため、算出されたトルクがしきい値以上になった場合、Pゲインをしきい値を偏差で除したものとすることで、擬似的なトルク上限を実現しています。
この実装ではPゲインからのトルクに制限をかけているため、Dゲインやトルク指令などには影響を及ぼさない実装となっています。
実験結果ではトルク上限近傍でトルクが頭打ちになっているため、機能していることは確認済みです。

トルクの上限は`torque_limit`で管理しています。設定値は9.0 Nmにしています。
この値は約300秒程度倒立ができ、温度上昇がゆるやかといった点から選んでいます。
必要に応じて変更していただいて問題ありません。
トルク上限を大きくすると温度上昇が早くなりますが、姿勢を維持する時間が長くなるトレードオフになっています。

